### PR TITLE
add: API通信時のローディング画面へのページ遷移作成

### DIFF
--- a/nativeApp/src/lib/sendPicture.js
+++ b/nativeApp/src/lib/sendPicture.js
@@ -26,7 +26,7 @@ async function sendImage({ uri }) {
         },
       }
     );
-    console.log(res.data);
+    console.log("responce data: " + res.data);
     return res.data;
   } catch (error) {
     console.error(error);

--- a/nativeApp/src/navigation/stacks/HomeStack.js
+++ b/nativeApp/src/navigation/stacks/HomeStack.js
@@ -4,6 +4,7 @@ import PictureScreen from "../../screens/PictureScreen";
 import { createStackNavigator } from "@react-navigation/stack";
 import { CameraProvider } from "../../context/CameraContext";
 import GetMaterialScreen from "../../screens/GetMaterialScreen";
+import SubmitToAPIScreen from "../../screens/SubmitToAPIScreen";
 
 const Stack = createStackNavigator();
 
@@ -14,6 +15,7 @@ const HomeScreenNavigator = () => {
         <Stack.Screen name="Home" component={HomeScreen} />
         <Stack.Screen name="Camera" component={CameraScreen} />
         <Stack.Screen name="Picture" component={PictureScreen} />
+        <Stack.Screen name="SubmitToAPI" component={SubmitToAPIScreen} />
         <Stack.Screen
           name="GetMaterial"
           component={GetMaterialScreen}

--- a/nativeApp/src/screens/GetMaterialScreen.js
+++ b/nativeApp/src/screens/GetMaterialScreen.js
@@ -31,9 +31,12 @@ const GetMaterialScreen = ({ route, navigation }) => {
       style={styles.container}
       onPress={() => navigation.navigate("Home")}
     >
-      <Text style={styles.title}>GET</Text>
-      <Image style={styles.material} source={images[getMaterial.pass2Photo]} />
-      <Text style={styles.materialNumText}>{`× ${getMaterialNum}`}</Text>
+        <Text style={styles.title}>GET</Text>
+        <Image
+          style={styles.material}
+          source={images[getMaterial.pass2Photo]}
+        />
+        <Text style={styles.materialNumText}>{`× ${getMaterialNum}`}</Text>
     </TouchableOpacity>
   );
 };

--- a/nativeApp/src/screens/HomeScreen.js
+++ b/nativeApp/src/screens/HomeScreen.js
@@ -68,9 +68,10 @@ const HomeScreen = ({ navigation }) => {
           },
           (location) => {
             setMyLocation(location);
-            console.log(
-              `latitude: ${location.coords.latitude}, longitude: ${location.coords.longitude}`
-            );
+            /* debug用 */
+            // console.log(
+            //   `latitude: ${location.coords.latitude}, longitude: ${location.coords.longitude}`
+            // );
           }
         );
         return () => {

--- a/nativeApp/src/screens/LoadingAnimationScreen.js
+++ b/nativeApp/src/screens/LoadingAnimationScreen.js
@@ -1,0 +1,36 @@
+import React, { useRef } from "react";
+import { StyleSheet, View } from "react-native";
+import LottieView from "lottie-react-native";
+
+const LoadingAnimationScreen = () => {
+  const animation = useRef(null);
+
+  return (
+    <View style={styles.animationContainer}>
+      <LottieView
+        autoPlay
+        loop={true}
+        ref={animation}
+        style={{
+          width: 500,
+          height: 500,
+        }}
+        source={require("../../assets/cooking.json")}
+        // 開発用（４倍速）
+        // source={require("../../assets/dev-cooking.json")}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  animationContainer: {
+    // lottieでカラーセット色々あるから試してみた方がいいかも
+    backgroundColor: "#F8DAD1",
+    alignItems: "center",
+    justifyContent: "center",
+    flex: 1,
+  },
+});
+
+export default LoadingAnimationScreen;

--- a/nativeApp/src/screens/PictureScreen.js
+++ b/nativeApp/src/screens/PictureScreen.js
@@ -1,36 +1,18 @@
-import React from "react";
 import { StyleSheet, View, Image, Dimensions } from "react-native";
 import { useCamera } from "../context/CameraContext";
 import ChangeMaterialButton from "../components/ChangeMaterialButton";
-import sendImage from "../lib/sendPicture";
-import { selectData } from "../lib/dataBaseHelper";
-import { RO, Material } from "../lib/databaseQueryText";
-import getRandomNum from "../lib/getRandomNum";
 
 const windowWidth = Dimensions.get("window").width;
 const windowHeight = Dimensions.get("window").height;
 
 const PictureScreen = ({ navigation }) => {
   const { picture } = useCamera();
+  console.log(picture)
+  
 
-  const handleSubmitToAPI = async () => {
-    const response = await sendImage({ uri: picture.uri });
-    selectData(
-      Material.tablename,
-      Material.elementsKey.colorId,
-      RO.Eqqual,
-      response.return
-    ).then((materials) => {
-      if (materials.length > 0) {
-        const randomIndx = getRandomNum(materials.length);
-        navigation.navigate("GetMaterial", {
-          getMaterial: materials[randomIndx],
-        });
-      } else {
-        console.log(
-          `colorId == ${response.return}のマテリアルが登録されていません`
-        );
-      }
+  const handleSubmitToAPI = () => {
+    navigation.navigate("SubmitToAPI", {
+      picture:picture,
     });
   };
   return (

--- a/nativeApp/src/screens/SubmitToAPIScreen.js
+++ b/nativeApp/src/screens/SubmitToAPIScreen.js
@@ -1,0 +1,38 @@
+import sendImage from "../lib/sendPicture";
+import { selectData } from "../lib/dataBaseHelper";
+import { RO, Material } from "../lib/databaseQueryText";
+import getRandomNum from "../lib/getRandomNum";
+import LoadingAnimationScreen from "./LoadingAnimationScreen";
+
+const SubmitToAPIScreen = ({ route, navigation }) => {
+  const uri = route.params.picture.uri;
+
+  const getImageProcessingPicture = async (uri) => {
+    const response = await sendImage({ uri: uri });
+    selectData(
+      Material.tablename,
+      Material.elementsKey.colorId,
+      RO.Eqqual,
+      response.return
+    ).then((materials) => {
+      if (materials.length > 0) {
+        const randomIndx = getRandomNum(materials.length);
+        navigation.navigate("GetMaterial", {
+          getMaterial: materials[randomIndx],
+        });
+      } else {
+        console.log(
+          `colorId == ${response.return}のマテリアルが登録されていません`
+        );
+      }
+    });
+  };
+
+  if (route != null) {
+    getImageProcessingPicture(uri);
+  }
+
+  return <LoadingAnimationScreen />;
+};
+
+export default SubmitToAPIScreen;


### PR DESCRIPTION
closed #77 

## やったこと
- 写真を撮って変換ボタンを押したタイミングでローディング画面に遷移するようにした．
- API通信，データベース処理が終了するまでアニメーションが流れ続ける，無限ループにしてある．
- 処理終了後に食材ゲットのページに飛んでゲット画面が現れる．
- コンソール画面が見づらかったので緯度経度のデータ取得出力をコメントアウトした．

## 確認事項
- 変換ボタン押したらアニメが流れる
- アニメがループする
- 終わったタイミングでゲット画面が現れる
- これら一連の流れが行われる
- アニメーションは調理画面のものを代替したので，実際に合うものを探す必要ある．