### PR TITLE
イベント作成のAPIリクエストに対する処理作成

### DIFF
--- a/api/api/main.py
+++ b/api/api/main.py
@@ -3,9 +3,5 @@ from api.routers import event
 
 app = FastAPI()
 
-@app.get("/hello")
-async def root():
-    return {"message": "Hello World"}
-
 app.include_router(event.router)
 

--- a/api/api/routers/event.py
+++ b/api/api/routers/event.py
@@ -2,7 +2,6 @@ from fastapi import APIRouter
 from typing import List
 from datetime import datetime
 import api.schemes.event as event_schema
-from datetime import date
 
 router = APIRouter()
 
@@ -12,7 +11,11 @@ async def list_events():
 
 @router.post("/events/create", response_model=event_schema.EventCreateResponse)
 async def create_event(event_body: event_schema.EventCreate):
-    return event_schema.EventCreateResponse(**event_body.model_dump()) # 現状はidをNULLで返す
+    # 新しいイベントのIDを生成します（ここでは仮に1としていますが、実際にはDBから取得します）
+    new_id = 1
+    event_data = event_body.model_dump()
+    event_data["id"] = new_id
+    return event_schema.EventCreateResponse(**event_data) # 現状はidをNULLで返す
 
 @router.get("/events/{event_id}", response_model=event_schema.EventDetail)
 async def read_event():

--- a/api/api/routers/event.py
+++ b/api/api/routers/event.py
@@ -1,20 +1,21 @@
 from fastapi import APIRouter
 from typing import List
 import api.schemes.event as event_schema
+from datetime import date
 
 router = APIRouter()
 
-@router.get("/events", response_model=List[event_schema.Event])
+@router.get("/events", response_model=List[event_schema.EventBase])
 async def list_events():
-    return [event_schema.Event(id=1, name="イベント1", organizer="主催者1", term="2021-01-01 ~ 2021-01-02")]
+    return [event_schema.EventBase(id=1, event_name="イベント1", organizer="主催者1", term=date(2024, 5, 10))]
 
-@router.post("/events/create")
-async def create_event():
-    pass
+@router.post("/events/create", response_model=event_schema.EventCreateResponse)
+async def create_event(event_body: event_schema.EventCreate):
+    return event_schema.EventCreateResponse(**event_body.model_dump()) # 現状はidをNULLで返す
 
 @router.get("/events/{event_id}", response_model=List[event_schema.EventDetail])
 async def read_event():
-    return [event_schema.EventDetail(id=1, name="イベント1", organizer="主催者", term="2021-01-01 ~ 2021-01-02", budge_image="ieyasu", target_img="hamamatsu_castle_img", target_name="hamamatsu_castle_name", position=[12.345, 234.5556])]
+    return [event_schema.EventDetail(id=1, event_name="イベント1", organizer="主催者", term=date(2024, 5, 10), overview="概要の説明", badge_img="ieyasu", target_img="hamamatsu_castle_img", target_name="hamamatsu_castle_name", position=[12.345, 3456.777])]
 
 @router.put("/events/{event_id}/edit")
 async def update_event():

--- a/api/api/schemes/event.py
+++ b/api/api/schemes/event.py
@@ -1,18 +1,26 @@
 from pydantic import BaseModel, Field
-from typing import Tuple
+from typing import Tuple, Optional
+from datetime import date
 
-class Event(BaseModel):
-    id:int
-    name:str = Field(None, title="イベント名")
-    organizer:str = Field(None, title="主催者")
-    term:str = Field(None, title="期間") # TODO: 日付型に変換するか？
+class EventBase(BaseModel):
+    id: Optional[int] = None  # DBで自動生成されるIDを入れるので, とりあえずNULLにしました
+    event_name: Optional[str] = Field(None, title="イベント名")
+    organizer: Optional[str] = Field(None, title="主催者")
+    term: Optional[date] = Field(None, title="期間")  # 日付型
 
-class EventDetail(BaseModel):
-    id:int
-    event_name:str = Field(None, title="イベント名")
-    organizer:str = Field(None, title="主催者")
-    term:str = Field(None, title="期間") # TODO: 日付型に変換するか？
-    badge_img:str = Field(None, title="バッジ画像(Base64)")
-    target_img:str = Field(None, title="撮影対象画像(Base64)")
-    target_name:str = Field(None, title="撮影対象名前")
-    position:Tuple[float, float] = Field(None, title="撮影場所") # TODO: 座標の型どう？
+    class Config:
+        from_attributes = True
+
+class EventDetail(EventBase): # EventBaseを継承する
+    overview: Optional[str] = Field(None, title="概要")
+    badge_img: Optional[str] = Field(None, title="バッジ画像(Base64)")
+    target_img: Optional[str] = Field(None, title="撮影対象画像(Base64)")
+    target_name: Optional[str] = Field(None, title="撮影対象名前")
+    position: Optional[Tuple[float, float]] = Field(None, title="撮影場所")  # 座標型
+
+class EventCreate(EventDetail):  # EventDetailを継承する
+    pass
+
+class EventCreateResponse(EventDetail):
+    class Config:
+        from_attributes = True

--- a/api/api/schemes/event.py
+++ b/api/api/schemes/event.py
@@ -15,3 +15,12 @@ class EventDetail(EventBase): # EventBaseを継承する
     target_name: str = Field(..., title="撮影対象名前")
     latitude: float = Field(..., title="緯度")
     longitude: float = Field(..., title="経度")
+
+class EventCreate(EventDetail):
+    pass
+
+class EventCreateResponse(EventCreate):
+    id: int = Field(..., title="ID")
+
+    class Config:
+        from_attributes = True

--- a/api/api/schemes/event.py
+++ b/api/api/schemes/event.py
@@ -2,13 +2,12 @@ from pydantic import BaseModel, Field
 from datetime import datetime
 
 class EventBase(BaseModel):
-    id: int = None  # DBで自動生成されるIDを入れるので, とりあえずNULLにしました
     event_name: str = Field(..., title="イベント名")
     organizer: str = Field(..., title="主催者")
     start_date: datetime = Field(..., title="開始日")
     end_date: datetime = Field(..., title="終了日")
 
-class EventDetail(EventBase): # EventBaseを継承する
+class EventDetailBase(EventBase): # EventBaseを継承する
     overview: str = Field(..., title="概要")
     badge_img: str = Field(..., title="バッジ画像(Base64)")
     target_img: str = Field(..., title="撮影対象画像(Base64)")
@@ -16,7 +15,12 @@ class EventDetail(EventBase): # EventBaseを継承する
     latitude: float = Field(..., title="緯度")
     longitude: float = Field(..., title="経度")
 
-class EventCreate(EventDetail):
+class Event(EventBase): # Event
+    id: int = None
+
+class EventDetail(EventDetailBase): # Event
+    id: int = None
+class EventCreate(EventDetailBase):
     pass
 
 class EventCreateResponse(EventCreate):


### PR DESCRIPTION
closed #170 

## やったこと
- イベント作成のPOSTメソッドに対する処理を作成した
- エンドポイント"/Hello"の処理いらないので消した

## 確認事項
- サーバを立ち上げた状態で http://localhost:8000/docs# を開き，POSTでAPIを実行した時に同じものがレスポンスとして帰ってくるか確認
- 自分はrequest bodyを以下のようにしました．
{
  "event_name": "Tech Conference 2024",
  "organizer": "Tech Corp",
  "start_date": "2024-05-10T00:00:00",
  "end_date": "2025-03-22T00:00:00",
  "overview": "A conference to showcase the latest in technology and innovation.",
  "badge_img": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA",
  "target_img": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA",
  "target_name": "Tech Innovations",
  "latitude": 37.7749,
  "longitude": -122.4194
}

※サーバの立ち上げ方
1. カレントディレクトリを PickNic/api にする
2. ターミナルで" poetry run uvicorn api.main:app --host 0.0.0.0 --reload " を実行するとサーバが立ち上がる