### PR TITLE
イベント一覧からイベント詳細ページに飛べるようにした

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "api",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/web/src/app/(app)/events/page.tsx
+++ b/web/src/app/(app)/events/page.tsx
@@ -14,12 +14,20 @@ type EventData = {
   organizer: string;
   start_date: string;
   end_date: string;
+  id: string;
 };
+
 
 // columns 配列に型を適用
 const columns: Column<EventData>[] = [
-  { Header: "イベント名", accessor: "event_name" },
-  { Header: "主催団体名", accessor: "organizer" },
+  { Header: "イベント名", accessor: "event_name" ,
+    Cell:({ row }) => 
+      (
+      <a href={`/events/${row.values.id}`} style={{ textDecoration: "none", color: "blue"}}>
+        {row.values.event_name}
+      </a>
+    )
+  },
   { Header: "開始日", accessor: "start_date" },
   { Header: "終了日", accessor: "end_date" },
 ];
@@ -35,7 +43,6 @@ export default function EventListPage() {
   const handleClickPictures = () => {
     router.push(`/events/create`);
   };
-
 
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
closed #191(対応するIssue番号を記入すると、PRがIssueと紐づく)

### やったこと
-イベント一覧からイベント名を押すとイベント詳細に飛ぶようにした

### 確認事項
- PickNic/api で poetry run uvicorn api.main:app --host 0.0.0.0 --reloadによってサーバを起動
- PickNic/web で　npm run devでサイト起動
- URLをクリック　 URL/events　からイベント名をクリックして、イベント詳細画面へ遷移することを確認してください。

