### PR TITLE
api起動用のスクリプトファイルの作成

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,4 @@
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run("api.main:app", host="0.0.0.0", port=8000, reload=True)


### PR DESCRIPTION
### やったこと

FastAPIサーバをapi直下のmain.pyから、`uvicorn.run()`を使用して立ち上げられるように変更しました。

### 確認事項
今後、以下のどちらかでAPIサーバを立ち上げられます。
APIサーバが起動することを確認してください。
```
// poetryの仮想環境に入る（コマンドの左に(api-py3.11)みたいのが出てくる）
// 仮想環境から出ない限り（exitを打つと出る）はpoetryの仮想環境下でコードが実行されます
poetry shell
// apiサーバの起動
python3 main.py
```
```
// poetryの仮装環境でapiサーバを起動
poetry run python3 main.py
```