### PR TITLE
ページ認証機能を加えたよ

### DIFF
--- a/web/src/app/(app)/events/page.tsx
+++ b/web/src/app/(app)/events/page.tsx
@@ -7,8 +7,7 @@ import { useRouter } from "next/navigation";
 import { Column } from "react-table";
 import { useState, useEffect } from "react";
 import axios from "axios";
-import { fetchAPIWithAuth } from "@/lib/api/helper";
-import { getToken, removeToken } from "@/lib/auth/token";
+import { useAuth } from "@/context/AuthContext";
 
 // 型定義
 type EventData = {
@@ -38,6 +37,7 @@ const columns: Column<EventData>[] = [
 ];
 
 export default function EventListPage() {
+  const { logout } = useAuth();
   const [events, setEvents] = useState<EventData[]>([]);
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
     useTable({
@@ -49,24 +49,7 @@ export default function EventListPage() {
     router.push(`/events/create`);
   };
 
-  const handleLogout = async () => {
-    const response = await fetchAPIWithAuth({
-      endpoint: "auth/logout",
-      method: "POST",
-    });
-    removeToken();
-    console.log(response);
-    console.log("token: " + getToken());
-  };
-
-  const handleFetchMe = async () => {
-    const response = await fetchAPIWithAuth({
-      endpoint: "auth/users/me",
-      method: "GET",
-    });
-    console.log(response);
-    console.log("token: " + getToken());
-  };
+  const handleLogout = async () => await logout();
 
   useEffect(() => {
     (async () => {
@@ -151,7 +134,6 @@ export default function EventListPage() {
           })}
         </tbody>
       </table>
-      <Button onClick={handleFetchMe} label="ログイン確認用" />
       <Button onClick={() => router.push("/login")} label="ログイン用" />
       <Button onClick={handleLogout} label="ログアウト用" />
     </PageTemplate>

--- a/web/src/app/(app)/layout.tsx
+++ b/web/src/app/(app)/layout.tsx
@@ -1,3 +1,4 @@
+import AuthGuard from "@/components/AuthGuard/AuthGuard";
 import Header from "@/components/Header/Header";
 
 export default function AppLayout({
@@ -6,24 +7,26 @@ export default function AppLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div
-      style={{
-        marginTop: 20,
-        marginRight: 30,
-        marginLeft: 30,
-      }}
-    >
-      <Header />
+    <AuthGuard>
       <div
         style={{
-          display: "flex",
-          paddingTop: 20,
-          paddingRight: 40,
-          paddingLeft: 40,
+          marginTop: 20,
+          marginRight: 30,
+          marginLeft: 30,
         }}
       >
-        {children}
+        <Header />
+        <div
+          style={{
+            display: "flex",
+            paddingTop: 20,
+            paddingRight: 40,
+            paddingLeft: 40,
+          }}
+        >
+          {children}
+        </div>
       </div>
-    </div>
+    </AuthGuard>
   );
 }

--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -5,27 +5,15 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { LoginSchemaType, loginSchema } from "@/schemas/loginSchema";
 import Button from "@/components/Button/Button";
 import InputField from "@/components/InputField/InputField";
-import { postLoginForm } from "@/lib/api/auth";
-import { toast } from "react-toastify";
-import { useRouter } from "next/navigation";
+import { useAuth } from "@/context/AuthContext";
 
 const LoginPage = () => {
-  const router = useRouter();
+  const { login } = useAuth();
   const formMethods = useForm<LoginSchemaType>({
     resolver: zodResolver(loginSchema),
   });
 
-  const handleLogin = async (data: LoginSchemaType) => {
-    const result = await postLoginForm(data);
-
-    if (result.success) {
-      toast.success(result.message);
-      formMethods.reset();
-      router.push("/events");
-    } else {
-      toast.error(result.message);
-    }
-  };
+  const handleLogin = async (data: LoginSchemaType) => await login(data);
 
   return (
     <div

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "/src/app/globals.css";
 import { Bounce, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import { AuthProvider } from "@/context/AuthContext";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -18,20 +19,22 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body className={inter.className} style={{ backgroundColor: "#FFF2D1" }}>
-        {children}
-        <ToastContainer
-          position="top-right"
-          autoClose={5000}
-          hideProgressBar={false}
-          newestOnTop={false}
-          closeOnClick
-          rtl={false}
-          pauseOnFocusLoss
-          draggable
-          pauseOnHover
-          theme="light"
-          transition={Bounce}
-        />
+        <AuthProvider>
+          {children}
+          <ToastContainer
+            position="top-right"
+            autoClose={5000}
+            hideProgressBar={false}
+            newestOnTop={false}
+            closeOnClick
+            rtl={false}
+            pauseOnFocusLoss
+            draggable
+            pauseOnHover
+            theme="light"
+            transition={Bounce}
+          />
+        </AuthProvider>
       </body>
     </html>
   );

--- a/web/src/components/AuthGuard/AuthGuard.tsx
+++ b/web/src/components/AuthGuard/AuthGuard.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useAuth } from "@/context/AuthContext";
+import { getMe } from "@/lib/api/auth";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { ReactNode, useEffect, useState } from "react";
+import { toast } from "react-toastify";
+
+const AuthGuard: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const { setUser } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [isLoading, setIsLoading] = useState(true);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    let ignore = false;
+
+    const checkAuth = async () => {
+      const result = await getMe();
+      if (!ignore) {
+        if (result.success) {
+          setIsAuthenticated(true);
+        } else {
+          setUser(null);
+          toast.error(result.message);
+          router.push("/login");
+        }
+        setIsLoading(false);
+      }
+    };
+
+    checkAuth();
+
+    return () => {
+      ignore = true;
+    };
+  }, [pathname, searchParams, setUser, router]);
+
+  if (isLoading) return null;
+
+  return isAuthenticated && <>{children}</>;
+};
+
+export default AuthGuard;

--- a/web/src/components/AuthGuard/AuthGuard.tsx
+++ b/web/src/components/AuthGuard/AuthGuard.tsx
@@ -7,7 +7,7 @@ import { ReactNode, useEffect, useState } from "react";
 import { toast } from "react-toastify";
 
 const AuthGuard: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const { setUser } = useAuth();
+  const { user, setUser } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -22,6 +22,7 @@ const AuthGuard: React.FC<{ children: ReactNode }> = ({ children }) => {
       if (!ignore) {
         if (result.success) {
           setIsAuthenticated(true);
+          !user && result.data && setUser(result.data);
         } else {
           setUser(null);
           toast.error(result.message);

--- a/web/src/components/Header/Header.tsx
+++ b/web/src/components/Header/Header.tsx
@@ -1,5 +1,9 @@
+"use client";
+
+import { useAuth } from "@/context/AuthContext";
+
 const Header = () => {
-  const userName = "ユーザー名";
+  const { user } = useAuth();
   return (
     <div
       style={{
@@ -26,7 +30,7 @@ const Header = () => {
           fontWeight: 500,
         }}
       >
-        {userName}
+        {user?.user.name}
       </div>
     </div>
   );

--- a/web/src/context/AuthContext.tsx
+++ b/web/src/context/AuthContext.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { postLoginForm, postLogout } from "@/lib/api/auth";
+import { removeToken, saveToken } from "@/lib/auth/token";
 import { LoginSchemaType } from "@/schemas/loginSchema";
 import AuthUser from "@/types/user";
 import { useRouter } from "next/navigation";
@@ -24,6 +25,9 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
 
   const login = async (data: LoginSchemaType) => {
     const result = await postLoginForm(data);
+    result.data &&
+      result.data.accessToken &&
+      saveToken(result.data.accessToken);
 
     if (result.success && result.data) {
       toast.success(result.message);
@@ -36,6 +40,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
 
   const logout = async () => {
     const result = await postLogout();
+    removeToken();
 
     if (result.success && result.data) {
       toast.success(result.message);

--- a/web/src/context/AuthContext.tsx
+++ b/web/src/context/AuthContext.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { postLoginForm, postLogout } from "@/lib/api/auth";
+import { LoginSchemaType } from "@/schemas/loginSchema";
+import AuthUser from "@/types/user";
+import { useRouter } from "next/navigation";
+import React, { createContext, useContext, useState, ReactNode } from "react";
+import { toast } from "react-toastify";
+
+interface AuthContextProps {
+  user: AuthUser | null;
+  setUser: React.Dispatch<React.SetStateAction<AuthUser | null>>;
+  login: (data: LoginSchemaType) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextProps | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const router = useRouter();
+
+  const login = async (data: LoginSchemaType) => {
+    const result = await postLoginForm(data);
+
+    if (result.success && result.data) {
+      toast.success(result.message);
+      setUser(result.data);
+      router.push("/events");
+    } else {
+      toast.error(result.message);
+    }
+  };
+
+  const logout = async () => {
+    const result = await postLogout();
+
+    if (result.success && result.data) {
+      toast.success(result.message);
+      setUser(null);
+      router.push("/login");
+    } else {
+      toast.error(result.message);
+    }
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, setUser, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = (): AuthContextProps => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within a AuthProvider");
+  }
+  return context;
+};

--- a/web/src/lib/api/auth.ts
+++ b/web/src/lib/api/auth.ts
@@ -65,14 +65,22 @@ export const postLogout = async (): Promise<
   }
 };
 
-export const getMe = async (): Promise<ApiResponse<null>> => {
+export const getMe = async (): Promise<ApiResponse<AuthUser | null>> => {
   try {
     const response = await fetchAPIWithAuth({
       endpoint: "auth/users/me",
       method: "GET",
     });
 
-    return { success: true, message: "セッションが有効です。", data: response };
+    const data = {
+      user: { id: response.id, name: response.username, email: response.email },
+      organization: {
+        id: response.organization_id,
+        name: response.organization_id,
+      },
+    };
+
+    return { success: true, message: "セッションが有効です。", data };
   } catch (error) {
     let userMessage = "エラーが発生しました。";
     if (error instanceof APIError && error.status === 401) {

--- a/web/src/lib/api/auth.ts
+++ b/web/src/lib/api/auth.ts
@@ -1,13 +1,14 @@
 import { LoginSchemaType } from "@/schemas/loginSchema";
-import { saveToken } from "../auth/token";
-import { fetchAPI } from "./helper";
+import { removeToken, saveToken } from "../auth/token";
+import { fetchAPI, fetchAPIWithAuth } from "./helper";
 import { ApiResponse } from "@/types/utils";
 import { APIError } from "./ApiError";
+import AuthUser from "@/types/user";
 
 export const postLoginForm = async ({
   username,
   password,
-}: LoginSchemaType): Promise<ApiResponse<void>> => {
+}: LoginSchemaType): Promise<ApiResponse<AuthUser | null>> => {
   try {
     const response = await fetchAPI({
       endpoint: "auth/login",
@@ -21,12 +22,61 @@ export const postLoginForm = async ({
       },
     });
 
+    const data = {
+      user: { id: response.id, name: response.username, email: response.email },
+      organization: {
+        id: response.organization_id,
+        name: response.organization_id,
+      },
+    };
+
     saveToken(response.access_token);
-    return { success: true, message: "ログインに成功しました。" };
+    return { success: true, message: "ログインに成功しました。", data };
   } catch (error) {
     let userMessage = "エラーが発生しました。";
     if (error instanceof APIError && error.status === 401) {
       userMessage = "メールアドレスあるいはパスワードが正しくありません。";
+    }
+    return { success: false, message: userMessage };
+  }
+};
+
+export const postLogout = async (): Promise<
+  ApiResponse<{ message: string } | null>
+> => {
+  try {
+    const response = await fetchAPIWithAuth({
+      endpoint: "auth/logout",
+      method: "POST",
+    });
+
+    removeToken();
+    return {
+      success: true,
+      message: "ログアウトに成功しました。",
+      data: response,
+    };
+  } catch (error) {
+    let userMessage = "エラーが発生しました。";
+    if (error instanceof APIError && error.status === 401) {
+      userMessage = "ログアウトに失敗しました。";
+    }
+    return { success: false, message: userMessage };
+  }
+};
+
+export const getMe = async (): Promise<ApiResponse<null>> => {
+  try {
+    const response = await fetchAPIWithAuth({
+      endpoint: "auth/users/me",
+      method: "GET",
+    });
+
+    return { success: true, message: "セッションが有効です。", data: response };
+  } catch (error) {
+    let userMessage = "エラーが発生しました。";
+    if (error instanceof APIError && error.status === 401) {
+      userMessage = "セッションが無効です。";
     }
     return { success: false, message: userMessage };
   }

--- a/web/src/lib/api/auth.ts
+++ b/web/src/lib/api/auth.ts
@@ -1,5 +1,4 @@
 import { LoginSchemaType } from "@/schemas/loginSchema";
-import { removeToken, saveToken } from "../auth/token";
 import { fetchAPI, fetchAPIWithAuth } from "./helper";
 import { ApiResponse } from "@/types/utils";
 import { APIError } from "./ApiError";
@@ -28,9 +27,9 @@ export const postLoginForm = async ({
         id: response.organization_id,
         name: response.organization_id,
       },
+      accessToken: response.access_token,
     };
 
-    saveToken(response.access_token);
     return { success: true, message: "ログインに成功しました。", data };
   } catch (error) {
     let userMessage = "エラーが発生しました。";
@@ -50,7 +49,6 @@ export const postLogout = async (): Promise<
       method: "POST",
     });
 
-    removeToken();
     return {
       success: true,
       message: "ログアウトに成功しました。",

--- a/web/src/types/user.ts
+++ b/web/src/types/user.ts
@@ -1,0 +1,15 @@
+export default interface AuthUser {
+  user: User;
+  organization: Organization;
+}
+
+interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+interface Organization {
+  id: string;
+  name: string;
+}

--- a/web/src/types/user.ts
+++ b/web/src/types/user.ts
@@ -1,6 +1,7 @@
 export default interface AuthUser {
   user: User;
   organization: Organization;
+  accessToken?: string;
 }
 
 interface User {


### PR DESCRIPTION
close #228 

### やったこと
- 認証情報の保持、認証系の関数を管理するコンテキスト`AuthContext`を作成したよ
  - user：`auth/users/me`などで得られるUser情報が入ってます
  - login
  - logout
- 認証ガードを行う`AuthGuard`コンポーネントを作成したよ
  - ページ遷移時に`auth/users/me`を叩き、アクセス権限があるか`(app)`以下で確認します
  - リロード時、`AuthContext`のsetUserも行います（usernameなどの状態変数がリロードでクリアされてしまうため）
- headerにusernameを表示したよ

### 起動方法
- api
```
poetry install
poetry shell
// 以下poetry shell内
python3 migrate.py
python3 main.py
```
- web
```
npm install
npm run dev
```
- アカウント情報
```
username: admin
password: password
```

### 確認事項
- ログイン後、`http://localhost:3000/events`などアプリページに遷移できることの確認
- ログアウト時（`http://localhost:3000/events`の「ログアウト確認用」押下）、ログインページにページ遷移することの確認
- 未ログイン時に`http://localhost:3000/events`などアプリページに遷移した際、「セッションが有効でない」という旨のポップアップとともにログインページに強制遷移することの確認。その際、一瞬でも`http://localhost:3000/events`などのページの内容が見れないことの確認
- Headerにusernameが表示できていることの確認