### PR TITLE
ユーザ一覧ページの作成

### DIFF
--- a/api/api/cruds/auth.py
+++ b/api/api/cruds/auth.py
@@ -10,6 +10,9 @@ def get_user_by_username(db: Session, username: str):
 def get_user_by_email(db: Session, email: str):
     return db.query(User).filter(User.email == email).first()
 
+def get_user_list_by_organization_id(db: Session, organization_id: str):
+    return db.query(User).filter(User.organization_id == organization_id).all()
+
 def create_user(db: Session, user: UserCreate, organization_id: int):
     db_user = User(
         username=user.username,

--- a/api/api/cruds/auth.py
+++ b/api/api/cruds/auth.py
@@ -10,6 +10,9 @@ def get_user_by_username(db: Session, username: str):
 def get_user_by_email(db: Session, email: str):
     return db.query(User).filter(User.email == email).first()
 
+def get_user_by_id(db: Session, id: str):
+    return db.query(User).filter(User.id == id).first()
+
 def get_user_list_by_organization_id(db: Session, organization_id: str):
     return db.query(User).filter(User.organization_id == organization_id).all()
 

--- a/api/api/routers/auth.py
+++ b/api/api/routers/auth.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 from jose import JWTError
 from datetime import timedelta
 from api.schemes.auth import UserCreate, UserUpdate, User, UserResponse, LoginResponse, BelongedOrganization, UsersResponse
-from api.cruds.auth import get_user_by_username, get_user_by_email, create_user,update_user,delete_user, get_user_list_by_organization_id
+from api.cruds.auth import get_user_by_username, get_user_by_email, create_user,update_user,delete_user, get_user_list_by_organization_id, get_user_by_id
 from api.lib.auth.auth_utils import verify_password
 from api.lib.auth.token_utils import create_access_token, decode_access_token,add_token_to_blacklist,is_token_in_blacklist,ACCESS_TOKEN_EXPIRE_MINUTES
 from api.database import get_db
@@ -80,5 +80,14 @@ async def login_for_access_token(token: str = Depends(oauth2_scheme)):
 @router.get("/auth/users/", response_model=UsersResponse)
 async def read_users(db: Session = Depends(get_db), belonged_organization: BelongedOrganization = Depends(get_belonged_organization)):
     user_list = get_user_list_by_organization_id(db, belonged_organization.organization_id)
-    print(user_list[0].username)
     return UsersResponse(users=user_list)
+
+@router.get("/auth/users/{user_id}", response_model=UserResponse)
+async def read_users(user_id: int, db: Session = Depends(get_db), belonged_organization: BelongedOrganization = Depends(get_belonged_organization)):
+    user = get_user_by_id(db, user_id)
+    if (user.organization_id != belonged_organization.organization_id):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to access this user")
+    return UserResponse(
+        organization_name=belonged_organization.organization_name,
+        **user.__dict__
+    )

--- a/api/api/routers/auth.py
+++ b/api/api/routers/auth.py
@@ -3,8 +3,8 @@ from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 from jose import JWTError
 from datetime import timedelta
-from api.schemes.auth import UserCreate, UserUpdate, User, UserResponse, LoginResponse, BelongedOrganization
-from api.cruds.auth import get_user_by_username, get_user_by_email, create_user,update_user,delete_user
+from api.schemes.auth import UserCreate, UserUpdate, User, UserResponse, LoginResponse, BelongedOrganization, UsersResponse
+from api.cruds.auth import get_user_by_username, get_user_by_email, create_user,update_user,delete_user, get_user_list_by_organization_id
 from api.lib.auth.auth_utils import verify_password
 from api.lib.auth.token_utils import create_access_token, decode_access_token,add_token_to_blacklist,is_token_in_blacklist,ACCESS_TOKEN_EXPIRE_MINUTES
 from api.database import get_db
@@ -76,3 +76,9 @@ async def delete_user_endpoint(user_id: int, db: Session = Depends(get_db)):
 @router.get("/auth/current_token/", response_model=dict)
 async def login_for_access_token(token: str = Depends(oauth2_scheme)):
     return {"access_token": token}
+
+@router.get("/auth/users/", response_model=UsersResponse)
+async def read_users(db: Session = Depends(get_db), belonged_organization: BelongedOrganization = Depends(get_belonged_organization)):
+    user_list = get_user_list_by_organization_id(db, belonged_organization.organization_id)
+    print(user_list[0].username)
+    return UsersResponse(users=user_list)

--- a/api/api/schemes/auth.py
+++ b/api/api/schemes/auth.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
 
 class UserBase(BaseModel):
     username: str
@@ -23,6 +23,12 @@ class UserResponse(User):
 
     class Config:
         from_attributes = True
+
+class UsersResponse(BaseModel):
+    users: List[User]
+
+    class Config:
+        orm_mode = True
 
 class BelongedOrganization(User):
     organization_name: str

--- a/web/src/app/(app)/layout.tsx
+++ b/web/src/app/(app)/layout.tsx
@@ -13,12 +13,17 @@ export default function AppLayout({
           marginTop: 20,
           marginRight: 30,
           marginLeft: 30,
+          display: "flex",
+          flexDirection: "column",
+          height: "calc(100vh - 20px)",
         }}
       >
         <Header />
         <div
           style={{
             display: "flex",
+            flexDirection: "column",
+            flex: 1,
             paddingTop: 20,
             paddingRight: 40,
             paddingLeft: 40,

--- a/web/src/app/(app)/users/[userId]/page.tsx
+++ b/web/src/app/(app)/users/[userId]/page.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import Button from "@/components/Button/Button";
+import PageTemplate from "@/components/PageTemplate/PageTemplate";
+import { useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
+import { useState, useEffect } from "react";
+import { deleteUser, getUser } from "@/lib/api/user";
+import { User } from "@/types/user";
+import { useApiSubmit } from "@/hooks/useApiSubmit";
+import { toast } from "react-toastify";
+
+type PropsType = {
+  label: string;
+  value: string;
+};
+
+const UserDetailText = (props: PropsType) => {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        borderBottom: "dashed",
+        marginTop: 10,
+        paddingBottom: 10,
+      }}
+    >
+      <div style={{ display: "flex", fontSize: 20, fontWeight: 600 }}>
+        {props.label}
+      </div>
+      <div style={{ display: "flex", paddingLeft: 20 }}>{props.value}</div>
+    </div>
+  );
+};
+
+const UserDetailPage = () => {
+  const [user, setUser] = useState<User | null>(null);
+  const router = useRouter();
+  const params = useParams();
+  const userId = params["userId"] as string;
+  const { onApiSubmit } = useApiSubmit(deleteUser);
+
+  const handleClickBuck = () => {
+    router.push(`/users`);
+  };
+  const handleClickDelate = async () => {
+    if (!userId) return;
+    const result = await onApiSubmit({ id: userId });
+    if (result.success) {
+      router.push(`/users`);
+    }
+  };
+
+  useEffect(() => {
+    (async () => {
+      try {
+        if (!userId) return;
+        const result = await getUser({ id: userId });
+        result.data && setUser(result.data);
+        if (!result.success) {
+          toast.error(result.message);
+        }
+      } catch (error) {
+        console.error("Error fetching data:", error);
+      }
+    })();
+  }, []);
+
+  return (
+    <PageTemplate titleLabel="ユーザ詳細">
+      <div style={{ display: "flex", justifyContent: "end", gap: 10 }}>
+        <Button onClick={handleClickBuck} label="戻る" />
+        <Button onClick={handleClickDelate} label="削除" />
+      </div>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          padding: 20,
+          gap: 10,
+        }}
+      >
+        {user && (
+          <>
+            <UserDetailText label="ユーザID" value={user.id} />
+            <UserDetailText label="ユーザ名" value={user.name} />
+            <UserDetailText label="メールアドレス" value={user.email} />
+          </>
+        )}
+      </div>
+    </PageTemplate>
+  );
+};
+
+export default UserDetailPage;

--- a/web/src/app/(app)/users/create/page.tsx
+++ b/web/src/app/(app)/users/create/page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import PageTemplate from "@/components/PageTemplate/PageTemplate";
+import { useForm, FormProvider } from "react-hook-form";
+import InputField from "@/components/InputField/InputField";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { userSchemaType, userSchema } from "@/schemas/userSchema";
+import Button from "@/components/Button/Button";
+import { postUserForm } from "@/lib/api/user";
+import { useApiSubmit } from "@/hooks/useApiSubmit";
+import AuthUser from "@/types/user";
+import { useEffect } from "react";
+
+export default function UserCreatePage() {
+  const { onApiSubmit, apiResponse } = useApiSubmit<
+    userSchemaType,
+    AuthUser | null
+  >(postUserForm);
+  const formMethods = useForm<userSchemaType>({
+    resolver: zodResolver(userSchema),
+  });
+
+  useEffect(() => {
+    if (apiResponse?.success) formMethods.reset();
+  }, [apiResponse]);
+
+  return (
+    <PageTemplate titleLabel="ユーザ登録" style={{ marginBottom: 200 }}>
+      <div
+        style={{
+          display: "flex",
+          height: "100%",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <FormProvider {...formMethods}>
+          <form
+            onSubmit={formMethods.handleSubmit(onApiSubmit)}
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 30,
+            }}
+          >
+            <InputField
+              size="large"
+              direction="row"
+              name={"username"}
+              label={"ユーザネーム"}
+              placeholder={"username"}
+            />
+
+            <InputField
+              size="large"
+              direction="row"
+              name={"email"}
+              label={"メールアドレス"}
+              placeholder={"emal@example.com"}
+            />
+
+            <InputField
+              type="password"
+              size="large"
+              direction="row"
+              name={"password"}
+              label={"パスワード"}
+              placeholder={"8文字以上12文字以下"}
+            />
+
+            <Button size="fit" label="登録" />
+          </form>
+        </FormProvider>
+      </div>
+    </PageTemplate>
+  );
+}

--- a/web/src/app/(app)/users/create/page.tsx
+++ b/web/src/app/(app)/users/create/page.tsx
@@ -10,6 +10,7 @@ import { postUserForm } from "@/lib/api/user";
 import { useApiSubmit } from "@/hooks/useApiSubmit";
 import AuthUser from "@/types/user";
 import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 export default function UserCreatePage() {
   const { onApiSubmit, apiResponse } = useApiSubmit<
@@ -19,9 +20,13 @@ export default function UserCreatePage() {
   const formMethods = useForm<userSchemaType>({
     resolver: zodResolver(userSchema),
   });
+  const router = useRouter();
 
   useEffect(() => {
-    if (apiResponse?.success) formMethods.reset();
+    if (apiResponse?.success) {
+      formMethods.reset();
+      router.push("/users");
+    }
   }, [apiResponse]);
 
   return (
@@ -69,6 +74,12 @@ export default function UserCreatePage() {
             />
 
             <Button size="fit" label="登録" />
+            <Button
+              type="button"
+              size="fit"
+              label="キャンセル"
+              onClick={() => router.push("/users")}
+            />
           </form>
         </FormProvider>
       </div>

--- a/web/src/app/(app)/users/page.tsx
+++ b/web/src/app/(app)/users/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+import React from "react";
+import { useTable } from "react-table";
+import PageTemplate from "@/components/PageTemplate/PageTemplate";
+import Button from "@/components/Button/Button";
+import { useRouter } from "next/navigation";
+import { Column } from "react-table";
+import { useState, useEffect } from "react";
+import { getUserList } from "@/lib/api/user";
+import { User } from "@/types/user";
+
+const columns: Column<User>[] = [
+  { Header: "ユーザ名", accessor: "name" },
+  { Header: "メールアドレス", accessor: "email" },
+];
+
+export default function UserListPage() {
+  const [users, setUsers] = useState<Array<User>>([]);
+  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
+    useTable({ columns, data: users });
+  const router = useRouter();
+  const handleNavigate = () => {
+    router.push(`/users/create`);
+  };
+
+  useEffect(() => {
+    (async () => {
+      const users = await getUserList();
+      users.data && setUsers(users.data);
+    })();
+  }, []);
+
+  return (
+    <PageTemplate titleLabel="ユーザ一覧">
+      <div>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "end",
+            padding: 0,
+            marginBottom: 10,
+          }}
+        >
+          <Button onClick={handleNavigate} label="ユーザ登録" />
+        </div>
+
+        <table
+          style={{
+            textAlign: "center",
+            width: "100%",
+            borderSpacing: 0,
+            tableLayout: "fixed",
+            border: "solid 1px #000",
+          }}
+          {...getTableProps()}
+        >
+          <thead
+            style={{
+              textAlign: "center",
+            }}
+          >
+            {headerGroups.map((headerGroup, idx) => (
+              <tr {...headerGroup.getHeaderGroupProps()} key={idx}>
+                {headerGroup.headers.map((column, idx) => (
+                  <th
+                    style={{
+                      width: "80%",
+                      tableLayout: "fixed",
+                      border: "1.5px #7e7e7e solid",
+                    }}
+                    {...column.getHeaderProps()}
+                    key={idx}
+                  >
+                    {column.render("Header")}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+
+          <tbody {...getTableBodyProps()}>
+            {rows.map((row, i) => {
+              prepareRow(row);
+              return (
+                <tr {...row.getRowProps()} key={i}>
+                  {row.cells.map((cell, i) => {
+                    return (
+                      <td
+                        style={{
+                          width: "80%",
+                          tableLayout: "fixed",
+                          border: "1.5px #7e7e7e solid",
+                        }}
+                        {...cell.getCellProps()}
+                        key={i}
+                      >
+                        {cell.render("Cell")}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </PageTemplate>
+  );
+}

--- a/web/src/app/(app)/users/page.tsx
+++ b/web/src/app/(app)/users/page.tsx
@@ -10,7 +10,18 @@ import { getUserList } from "@/lib/api/user";
 import { User } from "@/types/user";
 
 const columns: Column<User>[] = [
-  { Header: "ユーザ名", accessor: "name" },
+  {
+    Header: "ユーザ名",
+    accessor: "name",
+    Cell: ({ row }) => (
+      <a
+        href={`/users/${row.original.id}`}
+        style={{ textDecoration: "none", color: "blue" }}
+      >
+        {row.values.name}
+      </a>
+    ),
+  },
   { Header: "メールアドレス", accessor: "email" },
 ];
 

--- a/web/src/components/Button/Button.tsx
+++ b/web/src/components/Button/Button.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 type PropsType = {
+  type?: "submit" | "button" | "reset";
   label: string;
   onClick?: () => void;
   size?: "medium" | "fit";

--- a/web/src/components/Header/Header.tsx
+++ b/web/src/components/Header/Header.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useAuth } from "@/context/AuthContext";
+import { useRouter } from "next/navigation";
 
 const Header = () => {
   const { user } = useAuth();
+  const router = useRouter();
   return (
     <div
       style={{
@@ -14,20 +16,24 @@ const Header = () => {
       }}
     >
       <div
+        onClick={() => router.push("/events")}
         style={{
           fontSize: 48,
           lineHeight: 1,
           fontWeight: 700,
           color: "#FF914D",
+          cursor: "pointer",
         }}
       >
         PickNic
       </div>
       <div
+        onClick={() => router.push("/users")}
         style={{
           fontSize: 24,
           lineHeight: 2,
           fontWeight: 500,
+          cursor: "pointer",
         }}
       >
         {user?.user.name}

--- a/web/src/components/PageTemplate/PageTemplate.tsx
+++ b/web/src/components/PageTemplate/PageTemplate.tsx
@@ -1,16 +1,25 @@
-import { ReactNode } from "react";
+import { ReactNode, CSSProperties } from "react";
 import Title from "../Title/Title";
 
 type PropsType = {
   children: ReactNode;
   titleLabel: string;
+  style?: CSSProperties;
 };
 
 const PageTemplate = (props: PropsType) => {
   return (
-    <div style={{ width: "100%" }}>
+    <div
+      style={{
+        flex: 1,
+        width: "100%",
+        display: "flex",
+        flexDirection: "column",
+        ...props.style,
+      }}
+    >
       <Title label={props.titleLabel} />
-      {props.children}
+      <div style={{ flex: 1, width: "100%" }}>{props.children}</div>
     </div>
   );
 };

--- a/web/src/hooks/useApiSubmit.ts
+++ b/web/src/hooks/useApiSubmit.ts
@@ -1,0 +1,33 @@
+import { ApiResponse } from "@/types/utils";
+import { useState } from "react";
+import { toast } from "react-toastify";
+
+type FetchFunction<I, O> = (data: I) => Promise<ApiResponse<O>>;
+
+export const useApiSubmit = <I, O>(fetchFunction: FetchFunction<I, O>) => {
+  const [apiLoading, setLoading] = useState(false);
+  const [apiResponse, setApiResponse] = useState<ApiResponse<O> | null>(null);
+
+  const onApiSubmit = async (data: I) => {
+    setLoading(true);
+    try {
+      const result = await fetchFunction(data);
+      setApiResponse(result);
+
+      if (result.success) {
+        toast.success(result.message);
+      } else {
+        toast.error(result.message);
+      }
+      return result;
+    } catch (error) {
+      toast.error("エラーが発生しました。");
+      console.error(error);
+      return { success: false, message: "エラーが発生しました。", data: null };
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { onApiSubmit, apiLoading, apiResponse };
+};

--- a/web/src/lib/api/ApiError.ts
+++ b/web/src/lib/api/ApiError.ts
@@ -1,9 +1,11 @@
-export class APIError extends Error {
+export class ApiError extends Error {
   status: number;
+  detail: string;
 
-  constructor(message: string, status: number) {
+  constructor(message: string, status: number, detail: string) {
     super(message);
     this.status = status;
-    this.name = "APIError";
+    this.name = "ApiError";
+    this.detail = detail;
   }
 }

--- a/web/src/lib/api/auth.ts
+++ b/web/src/lib/api/auth.ts
@@ -1,7 +1,7 @@
 import { LoginSchemaType } from "@/schemas/loginSchema";
 import { fetchAPI, fetchAPIWithAuth } from "./helper";
 import { ApiResponse } from "@/types/utils";
-import { APIError } from "./ApiError";
+import { ApiError } from "./ApiError";
 import AuthUser from "@/types/user";
 
 export const postLoginForm = async ({
@@ -33,7 +33,7 @@ export const postLoginForm = async ({
     return { success: true, message: "ログインに成功しました。", data };
   } catch (error) {
     let userMessage = "エラーが発生しました。";
-    if (error instanceof APIError && error.status === 401) {
+    if (error instanceof ApiError && error.status === 401) {
       userMessage = "メールアドレスあるいはパスワードが正しくありません。";
     }
     return { success: false, message: userMessage };
@@ -56,7 +56,7 @@ export const postLogout = async (): Promise<
     };
   } catch (error) {
     let userMessage = "エラーが発生しました。";
-    if (error instanceof APIError && error.status === 401) {
+    if (error instanceof ApiError && error.status === 401) {
       userMessage = "ログアウトに失敗しました。";
     }
     return { success: false, message: userMessage };
@@ -81,7 +81,7 @@ export const getMe = async (): Promise<ApiResponse<AuthUser | null>> => {
     return { success: true, message: "セッションが有効です。", data };
   } catch (error) {
     let userMessage = "エラーが発生しました。";
-    if (error instanceof APIError && error.status === 401) {
+    if (error instanceof ApiError && error.status === 401) {
       userMessage = "セッションが無効です。";
     }
     return { success: false, message: userMessage };

--- a/web/src/lib/api/helper.ts
+++ b/web/src/lib/api/helper.ts
@@ -1,5 +1,5 @@
 import { getToken } from "../auth/token";
-import { APIError } from "./ApiError";
+import { ApiError } from "./ApiError";
 
 type optionType = {
   endpoint: string;
@@ -45,10 +45,11 @@ export const fetchAPI = async ({
       options
     );
     if (!response.ok) {
-      const errorText = await response.text();
-      const error = new APIError(
-        `HTTP error! status: ${response.status}, response: ${errorText}`,
-        response.status
+      const errorRes = await response.json();
+      const error = new ApiError(
+        `HTTP error! status: ${response.status}`,
+        response.status,
+        errorRes.detail
       );
       throw error;
     }

--- a/web/src/lib/api/user.ts
+++ b/web/src/lib/api/user.ts
@@ -1,8 +1,32 @@
 import { userSchemaType } from "@/schemas/userSchema";
 import { ApiResponse } from "@/types/utils";
 import { fetchAPIWithAuth } from "./helper";
-import AuthUser from "@/types/user";
+import AuthUser, { User } from "@/types/user";
 import { ApiError } from "./ApiError";
+
+export const getUserList = async (): Promise<ApiResponse<Array<User>>> => {
+  try {
+    const response = await fetchAPIWithAuth({
+      endpoint: "auth/users/",
+      method: "GET",
+    });
+
+    // TODO: userがany型になってしまった。fetchAPIにジェネリックで型指定する必要有
+    const data = response.users.map((user: any) => ({
+      id: user.id,
+      name: user.username,
+      email: user.email,
+    }));
+
+    return { success: true, message: "ユーザ取得に成功しました。", data };
+  } catch (error) {
+    let userMessage = "エラーが発生しました。";
+    if (error instanceof ApiError && error.status === 400) {
+      userMessage = error.detail;
+    }
+    return { success: false, message: userMessage };
+  }
+};
 
 export const postUserForm = async ({
   username,

--- a/web/src/lib/api/user.ts
+++ b/web/src/lib/api/user.ts
@@ -1,0 +1,40 @@
+import { userSchemaType } from "@/schemas/userSchema";
+import { ApiResponse } from "@/types/utils";
+import { fetchAPIWithAuth } from "./helper";
+import AuthUser from "@/types/user";
+import { ApiError } from "./ApiError";
+
+export const postUserForm = async ({
+  username,
+  email,
+  password,
+}: userSchemaType): Promise<ApiResponse<AuthUser | null>> => {
+  try {
+    const response = await fetchAPIWithAuth({
+      endpoint: "auth/users/",
+      method: "POST",
+      body: {
+        username: username,
+        email: email,
+        password: password,
+      },
+    });
+
+    const data = {
+      user: { id: response.id, name: response.username, email: response.email },
+      organization: {
+        id: response.organization_id,
+        name: response.organization_id,
+      },
+      accessToken: response.access_token,
+    };
+
+    return { success: true, message: "ユーザ作成に成功しました。", data };
+  } catch (error) {
+    let userMessage = "エラーが発生しました。";
+    if (error instanceof ApiError && error.status === 400) {
+      userMessage = error.detail;
+    }
+    return { success: false, message: userMessage };
+  }
+};

--- a/web/src/lib/api/user.ts
+++ b/web/src/lib/api/user.ts
@@ -4,6 +4,33 @@ import { fetchAPIWithAuth } from "./helper";
 import AuthUser, { User } from "@/types/user";
 import { ApiError } from "./ApiError";
 
+export const getUser = async ({
+  id,
+}: {
+  id: string;
+}): Promise<ApiResponse<User>> => {
+  try {
+    const response = await fetchAPIWithAuth({
+      endpoint: `auth/users/${id}`,
+      method: "GET",
+    });
+
+    const data = {
+      id: response.id,
+      name: response.username,
+      email: response.email,
+    };
+
+    return { success: true, message: "ユーザ取得に成功しました。", data };
+  } catch (error) {
+    let userMessage = "エラーが発生しました。";
+    if (error instanceof ApiError) {
+      userMessage = error.detail;
+    }
+    return { success: false, message: userMessage };
+  }
+};
+
 export const getUserList = async (): Promise<ApiResponse<Array<User>>> => {
   try {
     const response = await fetchAPIWithAuth({
@@ -54,6 +81,33 @@ export const postUserForm = async ({
     };
 
     return { success: true, message: "ユーザ作成に成功しました。", data };
+  } catch (error) {
+    let userMessage = "エラーが発生しました。";
+    if (error instanceof ApiError && error.status === 400) {
+      userMessage = error.detail;
+    }
+    return { success: false, message: userMessage };
+  }
+};
+
+export const deleteUser = async ({
+  id,
+}: {
+  id: string;
+}): Promise<ApiResponse<User>> => {
+  try {
+    const response = await fetchAPIWithAuth({
+      endpoint: `auth/users/delete/${id}`,
+      method: "DELETE",
+    });
+
+    const data = {
+      id: response.id,
+      name: response.username,
+      email: response.email,
+    };
+
+    return { success: true, message: "ユーザ削除に成功しました。", data };
   } catch (error) {
     let userMessage = "エラーが発生しました。";
     if (error instanceof ApiError && error.status === 400) {

--- a/web/src/schemas/userSchema.ts
+++ b/web/src/schemas/userSchema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const userSchema = z.object({
+  username: z
+    .string()
+    .min(3, { message: "ユーザ名は３文字以上の必要があります" })
+    .max(12, { message: "ユーザ名は12文字以上の必要があります" }),
+  email: z.string().email({ message: "メールアドレスの形式ではありません" }),
+  password: z
+    .string()
+    .min(8, { message: "パスワードは８文字以上の必要があります" })
+    .max(12, { message: "パスワードは12文字以下の必要があります" }),
+});
+
+export type userSchemaType = z.infer<typeof userSchema>;

--- a/web/src/types/user.ts
+++ b/web/src/types/user.ts
@@ -4,7 +4,7 @@ export default interface AuthUser {
   accessToken?: string;
 }
 
-interface User {
+export interface User {
   id: string;
   name: string;
   email: string;


### PR DESCRIPTION
close #230 
ブランチ切り忘れました //

### やったこと
- api submit用のhooksを作りました
  - APIフェッチ関数を引数に与えると、成功・失敗ポップ表示をしてくれます
  - 使用例
  ```javascript
  const { onApiSubmit, apiResponse } = useApiSubmit<
    userSchemaType,
    AuthUser | null
  >(postUserForm);
  ```
- user登録用ページを作りました`users/create`
  - 同じオーガニゼーションに属するユーザを作れます
- user一覧ページを作りました`users/`
  - 同じオーガニゼーションに属するユーザ一覧がみれます
  - apiのエンドポイントも作成しました
- user詳細ページを作りました`users/{user_id}`
  - 同じオーガニゼーションに属するユーザ一がみれます
  - apiのエンドポイントも作りました

### 起動方法
#229 など確認

### 確認事項
1. `admin`でログイン後、ユーザ名からユーザ一覧をみれるようにしているのでユーザ一覧に遷移
2. `admin`が登録されていることを確認
3. ユーザ登録ができることの確認（一覧に追加される）、2,3回やってください
4. ユーザ削除ができることの確認（詳細ページに遷移して削除できる）
5. 以下でログインしなおす
```
admin2
password
```
6. ユーザ一覧に遷移して、adminの時に見れたユーザが見れないことの確認（異なるオーガニゼーションに属するため）
7. `http://localhost:3000/users/1`に移動して、異なるオーガニゼーションのユーザ情報が見れないことの確認

### 備考
7 の時点で削除をすると削除ができます。気力があったら直してもらおうと思います。（本質ではないです。）
> APIに認証ロックがかかってないため（ログインしなくても削除可能）