### PR TITLE
モバイルからイベントに写真を投稿できるようにしたよ

### DIFF
--- a/api/api/cruds/event.py
+++ b/api/api/cruds/event.py
@@ -179,6 +179,15 @@ def update_event(db: Session, event_id:int, event_update:event_schema.EventUpdat
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+    
+def update_event_with_photo_id(db: Session, event_id: int, photo_id: int):
+    db_event = db.query(event_model.Event).filter(event_model.Event.id == event_id).first()
+    if db_event:
+        db_event.photo_id = photo_id
+        db_event.update_date = dt_now
+        db.commit()
+        db.refresh(db_event)
+    return db_event
 
 def update_organization(db: Session, organization_id:int, name:str):
     try:

--- a/api/api/cruds/event.py
+++ b/api/api/cruds/event.py
@@ -117,7 +117,7 @@ def create_photo(db: Session, photo_create: event_schema.EventCreate, event_id:i
         print("Start registering event photo...")
         db_photo = event_model.Photo(
             event_id=event_id,
-            pass_2_photo="画像保存先のURL，現在は固定値",
+            pass_2_photo=photo_create.target_img,
             latitude=photo_create.latitude,
             longitude=photo_create.longitude,
             create_date=dt_now,
@@ -140,7 +140,7 @@ def create_event_badge(db: Session, event_badge_create: event_schema.EventCreate
         db_event_badge = event_model.EventBadge(
             event_id=event_id,
             name=event_badge_create.badge_name,
-            pass_2_photo="バッジ画像保存先のURL，現在は固定値",
+            pass_2_photo=event_badge_create.badge_img,
             create_date=dt_now,
             update_date=dt_now
         )

--- a/api/api/cruds/mobile.py
+++ b/api/api/cruds/mobile.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 #from api.models.mobile import MobileUser
 from sqlalchemy import select
 from api.models.database_models import MobileUser,Photo, Event, Photo2MobileUser
-from api.schemes.mobile import MobileCreate, MobileUpdate,MobileCommit,Mobile
+from api.schemes.mobile import MobileCreate, MobileUpdate
 from api.schemes.photo2user import Photo2User
 from api.lib.auth.auth_utils import get_password_hash
 from datetime import datetime, timedelta
@@ -18,6 +18,13 @@ def get_mobile_user_all(db: Session):
 def get_mobile_user_by_Id(db: Session, id: str):
     print("get_user_by_username In crud.py",id)
     return db.query(MobileUser).filter(MobileUser.id == id).first()
+
+def get_mobile_photo_by_id(db: Session, mobile_user_id):
+    photo_2_mobile_user = db.query(Photo2MobileUser).filter(Photo2MobileUser.user_id==mobile_user_id).first()
+    if not photo_2_mobile_user:
+        raise HTTPException(status_code=404, detail="Photo2MobileUser not found")
+    mobile_photo = db.query(Photo).filter(Photo.id==photo_2_mobile_user.photo_id).first()
+    return mobile_photo
 
 def get_event_photo_by_id(db: Session, event_id:int):
     event = db.query(Event).filter(Event.id==event_id).first()

--- a/api/api/cruds/photo2user.py
+++ b/api/api/cruds/photo2user.py
@@ -19,6 +19,13 @@ def get_photo2Mobile_Relation_by_mobile_id(db: Session, id: str):
     print("get_photo2Mobile_Relation_by_mobile_id In crud.py",id)
     return db.query(Photo2MobileUser).filter(Photo2MobileUser.user_id == id).all()
 
+def get_photo2Mobile_Relation_by_user_and_event(db: Session, user_id: str, event_id: int):
+    photo_ids_subquery = db.query(Photo2MobileUser.photo_id).filter(Photo2MobileUser.user_id == user_id).subquery()
+    return (db.query(Photo2MobileUser)
+        .join(Photo, Photo2MobileUser.photo_id == Photo.id)
+        .filter(Photo2MobileUser.photo_id.in_(photo_ids_subquery), Photo.event_id == event_id)
+        .first())
+
 def create_photo2Mobile(db: Session, newItem: Photo2UserCreate):
     #print("create:",new_id,user)
     db_user = Photo2MobileUser(

--- a/api/api/cruds/photo2user.py
+++ b/api/api/cruds/photo2user.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 from api.models.database_models import Photo,Photo2MobileUser, MobileUser
 from api.schemes.photo2user import Photo2UserCreate, Photo2UserUpdate
 from api.lib.upload_image_to_s3 import upload_image_to_s3
-from api.cruds.mobile import get_event_photo_by_id, get_mobile_user_by_Id
+from api.cruds.mobile import get_mobile_photo_by_id, get_mobile_user_by_Id
 import os
 
 def get_photo2Mobile_Relation_by_id(db: Session, id: int):
@@ -67,9 +67,9 @@ def update_user_photo(db:Session, contents:bytes, user_id:str, event_id:int):
     bucket_name = os.getenv('S3_BUCKET_NAME')
     file_key = upload_image_to_s3(aws_access_key_id, aws_secret_access_key, endpoint_url, bucket_name, contents, user_name, event_id)
 
-    photo = get_event_photo_by_id(db, event_id)
+    photo = get_mobile_photo_by_id(db, mobile_user.id)
     if photo is None:
-        raise ValueError(f"No photo found for event_id {event_id}")
+        raise ValueError(f"No photo found for mobile_user {mobile_user}")
     photo.pass_2_photo = file_key
 
     db.commit()

--- a/api/api/cruds/photo2user.py
+++ b/api/api/cruds/photo2user.py
@@ -61,11 +61,8 @@ def update_user_photo(db:Session, contents:bytes, user_id:str, event_id:int):
         raise ValueError(f"No user found for user_id {user_id} in update_user_photo()")
     user_name = mobile_user.name
 
-    aws_access_key_id = os.getenv('AWS_ACCESS_KEY')
-    aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY')
-    endpoint_url=os.getenv('R2_ENDPOINT_URL')
-    bucket_name = os.getenv('S3_BUCKET_NAME')
-    file_key = upload_image_to_s3(aws_access_key_id, aws_secret_access_key, endpoint_url, bucket_name, contents, user_name, event_id)
+    file_key = f"{event_id}/user-photos/{user_name}.jpg"
+    upload_image_to_s3(file_key, body=contents)
 
     photo = get_mobile_photo_by_id(db, mobile_user.id)
     if photo is None:

--- a/api/api/lib/upload_image_to_s3.py
+++ b/api/api/lib/upload_image_to_s3.py
@@ -4,17 +4,23 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-def upload_image_to_s3(aws_access_key_id, aws_secret_access_key, endpoint_url, bucket_name, contents, user_name, event_id):
+def create_s3_client():
+    aws_access_key_id = os.getenv('AWS_ACCESS_KEY')
+    aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY')
+    endpoint_url=os.getenv('R2_ENDPOINT_URL')
+    return boto3.client('s3',
+                    region_name='auto',
+                    endpoint_url=endpoint_url,
+                    aws_access_key_id=aws_access_key_id,
+                    aws_secret_access_key=aws_secret_access_key)
+
+def upload_image_to_s3(key, body):
     # S3クライアントの作成
-    s3 = boto3.client('s3',
-                      region_name='auto',
-                      endpoint_url=endpoint_url,
-                      aws_access_key_id=aws_access_key_id,
-                      aws_secret_access_key=aws_secret_access_key)
+    s3 = create_s3_client()
 
-    file_key = f"{event_id}/user-photos/{user_name}.jpg" # {event_id}/user-photos/{user_name}.jpg
     # 画像をアップロード
-    s3.put_object(Bucket=bucket_name, Key=file_key, Body=contents)
-    print(f"Image successfully updated to S3: {user_name}")
+    bucket = os.getenv('S3_BUCKET_NAME')
+    result = s3.put_object(Bucket=bucket, Key=key, Body=body)
+    print(f"Image successfully updated to S3: {key}")
 
-    return file_key
+    return result

--- a/api/api/routers/event.py
+++ b/api/api/routers/event.py
@@ -24,6 +24,8 @@ def create_event(event_body: event_schema.EventCreate, current_user: User = Depe
 
     db_event_badge = event_cruds.create_event_badge(db, event_body, db_event_id)
 
+    event_cruds.update_event_with_photo_id(db, db_event_id, db_photo_id)
+
     create_event_data = event_body.model_dump()
     create_event_data["event_id"] = db_event_id
     create_event_data["organization_id"] = db_organization_id

--- a/api/api/routers/event.py
+++ b/api/api/routers/event.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 from api.routers.auth import get_current_user
 from api.models.database_models import User, Event
 from api.dependencies.auth import get_owned_event
+from api.lib.upload_image_to_s3 import upload_image_to_s3
 
 router = APIRouter()
 

--- a/nativeApp/src/lib/sendPicture.js
+++ b/nativeApp/src/lib/sendPicture.js
@@ -3,7 +3,12 @@ import * as FileSystem from "expo-file-system";
 import axios from "axios";
 import { API_URL } from "@env";
 
-async function sendImage({ endpoint = "uploadfile", uri }) {
+async function sendImage({
+  headers = {},
+  endpoint = "uploadfile",
+  uri,
+  body = {},
+}) {
   // 画像URIからBase64エンコードされたデータを取得
   const base64 = await FileSystem.readAsStringAsync(uri, {
     encoding: "base64",
@@ -16,10 +21,15 @@ async function sendImage({ endpoint = "uploadfile", uri }) {
     type: "image/jpeg",
   });
 
+  Object.keys(body).forEach((key) => {
+    data.append(key, body[key]);
+  });
+
   // axiosを使用してデータをPOST
   try {
     const res = await axios.post(`${API_URL}/${endpoint}`, data, {
       headers: {
+        ...headers,
         "Content-Type": "multipart/form-data",
       },
     });

--- a/nativeApp/src/screens/Event/SubmitScreen.js
+++ b/nativeApp/src/screens/Event/SubmitScreen.js
@@ -4,6 +4,8 @@ import { useLayoutEffect, useState } from "react";
 import LoadingScreen from "./LoadingScreen";
 import MyButton from "../../components/MyButton";
 import sendImage from "../../lib/sendPicture";
+import { useLocation } from "../../context/LocationContext";
+import { get_user_Wedid } from "../../lib/dataBaseHelper";
 
 const windowWidth = Dimensions.get("window").width;
 const windowHeight = Dimensions.get("window").height;
@@ -11,6 +13,7 @@ const windowHeight = Dimensions.get("window").height;
 const SubmitScreen = ({ navigation, route }) => {
   const [loading, setLoading] = useState(false);
   const { picture } = useCamera();
+  const { location } = useLocation();
 
   const eventId = route.params.eventId;
 
@@ -24,9 +27,19 @@ const SubmitScreen = ({ navigation, route }) => {
   const handleSubmitToAPI = async () => {
     setLoading(true);
     try {
+      const userId = await get_user_Wedid();
       const score = await sendImage({
         uri: picture.uri,
+        headers: {
+          "x-user-id": userId,
+          accept: "application/json",
+          "Content-Type": "multipart/form-data",
+        },
         endpoint: `mobile/events/${eventId}/uploadfile`,
+        body: {
+          latitude: location.coords.latitude,
+          longitude: location.coords.longitude,
+        },
       });
 
       setLoading(false);
@@ -34,7 +47,9 @@ const SubmitScreen = ({ navigation, route }) => {
       navigation.navigate("Result", {
         score: Math.round(parseFloat(score.return)),
       });
-    } catch (error) {}
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return loading ? (

--- a/nativeApp/src/screens/Event/SubmitScreen.js
+++ b/nativeApp/src/screens/Event/SubmitScreen.js
@@ -33,7 +33,6 @@ const SubmitScreen = ({ navigation, route }) => {
         headers: {
           "x-user-id": userId,
           accept: "application/json",
-          "Content-Type": "multipart/form-data",
         },
         endpoint: `mobile/events/${eventId}/uploadfile`,
         body: {


### PR DESCRIPTION
close #251 

### やったこと
- モバイルからユーザIDのヘッダと座標のボディを入れて画像送信できるようにしたよ
- APIの画像受信エンドポイント（`/mobile/events/{event_id}/photo_ranking`）で必要なレコードの登録をできるようにしたよ
  - ユーザが初めてイベントの写真を送る時（Photo2Userレコードがないとき）
    - Photoを登録
    - Photo２Userを登録
    - R2に画像を保存
  - ユーザが得点を更新した時（Photo2User.scoreより今回の特典の方が高かった時）
    - Photo２Userを更新
    - R2の画像を更新

### 確認事項
- 最初にDBタブからDropTableをして、アプリをリロードしてください
- イベントからEvent１に写真を送信して以下を確認
  - エラーがない
  - Event1のランキングに登録されている
  - R2の`1/user-photos`に`自分のユーザ名＋.jpg`で撮った写真が登録されている
- `api/api/routers/mobile.py`の223行目を`ret=10`などにして、Event1に写真を送信
  - エラーがない
  - Event1のランキングが更新されている
  - R2の`1/user-photos`に`自分のユーザ名＋.jpg`で撮った写真が更新されている
- `api/api/routers/mobile.py`の223行目を`ret=0`に戻して、Event1に写真を送信
  - エラーがない
  - Event1のランキングが更新されていない
  - R2の`1/user-photos`に`自分のユーザ名＋.jpg`が撮った写真で更新されていない
- 余力があったら上記をEvent2でも行なってください（同様の結果を期待します）